### PR TITLE
Fix sidebar collapse not expanding content

### DIFF
--- a/src/renderer/src/components/Layout/index.tsx
+++ b/src/renderer/src/components/Layout/index.tsx
@@ -172,6 +172,7 @@ export const Layout: React.FC<LayoutProps> = ({
         </div>
       </div>
       <ResizablePanelGroup
+        key={isSidebarCollapsed ? 'collapsed' : 'expanded'}
         direction='horizontal'
         className='flex-1 [&>div[role=separator]]:w-2 [&>div[role=separator]]:bg-transparent [&>div[role=separator]]:transition-colors [&>div[role=separator]]:hover:bg-accent/10'
         onLayout={handleSidebarResize}

--- a/src/renderer/src/components/Layout/index.tsx
+++ b/src/renderer/src/components/Layout/index.tsx
@@ -107,16 +107,28 @@ export const Layout: React.FC<LayoutProps> = ({
 
   // 处理折叠状态变化
   const handleToggleCollapse = useCallback(() => {
-    if (!isSidebarCollapsed) {
-      // 折叠时保存当前宽度
+    const willCollapse = !isSidebarCollapsed
+
+    if (willCollapse) {
+      // 折叠：保存当前宽度并发送 0 宽度到主进程
       setLastSidebarSize(sidebarSize)
       setSidebarSize(0)
+      sendUpdate(0, true)
     } else {
-      // 展开时恢复到上次的宽度
+      // 展开：恢复上次宽度并同步到主进程
       setSidebarSize(lastSidebarSize)
+      const sidebarWidthPx = Math.floor(
+        (window.innerWidth * lastSidebarSize) / 100
+      )
+      const boundedWidth = Math.max(
+        MIN_SIDEBAR_WIDTH,
+        Math.min(sidebarWidthPx, MAX_SIDEBAR_WIDTH)
+      )
+      sendUpdate(boundedWidth, false)
     }
-    setIsSidebarCollapsed(!isSidebarCollapsed)
-  }, [isSidebarCollapsed, sidebarSize, lastSidebarSize])
+
+    setIsSidebarCollapsed(willCollapse)
+  }, [isSidebarCollapsed, sidebarSize, lastSidebarSize, sendUpdate])
 
   // 暴露折叠状态变化的回调
   useEffect(() => {


### PR DESCRIPTION
Send immediate resize events to the main process when collapsing/expanding the sidebar to ensure `WebContentsView` fills the available space.

Previously, the `WebContentsView` on the right did not automatically expand to fill the available space when the left sidebar was collapsed. This change ensures that the main process is immediately notified of the sidebar's new width (0 when collapsed, or its previous width when expanded), allowing it to correctly update the `WebContentsView`'s bounds.

---
<a href="https://cursor.com/background-agent?bcId=bc-b3ef5394-b5d8-48eb-8bfa-f29d4b215f41">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b3ef5394-b5d8-48eb-8bfa-f29d4b215f41">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

