### PR TITLE
Fix latest workflow error

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -45,7 +45,7 @@ mac:
     - NSDownloadsFolderUsageDescription: Application requests access to the user's Downloads folder.
   notarize: false
 dmg:
-  artifactName: ${name}-${version}.${ext}
+  artifactName: ${name}-${version}-${arch}.${ext}
 linux:
   target:
     - AppImage


### PR DESCRIPTION
Add architecture to DMG artifact name to prevent build collisions on macOS.

The macOS build process creates both x64 and arm64 DMG files. Previously, both builds attempted to create an artifact with the same name (`${name}-${version}.dmg`), leading to a filename collision and `hdiutil` cleanup errors during the second build. Including `${arch}` in the artifact name ensures unique filenames for each architecture, resolving the build failure.

---
<a href="https://cursor.com/background-agent?bcId=bc-37d832c6-baf0-411b-9879-c7e15cc311a4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-37d832c6-baf0-411b-9879-c7e15cc311a4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

