### PR TITLE
Build and package electron app for linux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,6 @@ jobs:
           name: dist-linux
           path: |
             dist/*.AppImage
-            dist/*.snap
             dist/*.deb
             dist/*.rpm
 
@@ -109,7 +108,6 @@ jobs:
             dist/*.exe
             dist/*.dmg
             dist/*.AppImage
-            dist/*.snap
             dist/*.deb
             dist/*.rpm
         env:

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -49,7 +49,6 @@ dmg:
 linux:
   target:
     - AppImage
-    - snap
     - deb
   maintainer: electronjs.org
   category: Utility

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
     "dev": "electron-vite dev",
     "build": "npm run typecheck && electron-vite build",
     "postinstall": "electron-builder install-app-deps",
-    "build:win": "rimraf dist && npm run build && electron-builder --win --config",
+    "build:win": "rimraf dist && npm run build && electron-builder --win --config --publish=never",
     "build:mac": "rimraf dist && npm run build && electron-builder --mac --config --publish=never",
-    "build:linux": "rimraf dist && npm run build && electron-builder --linux --config"
+    "build:linux": "rimraf dist && npm run build && electron-builder --linux --config --publish=never"
   },
   "dependencies": {
     "@electron-toolkit/preload": "^3.0.0",


### PR DESCRIPTION
Remove Snap target and disable auto-publish for Linux/Windows builds to fix CI failures due to missing `snapcraft`.

The CI pipeline was failing on Linux builds with `snapcraft is not installed` and `ERR_ELECTRON_BUILDER_CANNOT_EXECUTE` errors. This PR resolves the issue by removing the Snap target from the build configuration and the CI workflow, allowing the Linux build to complete successfully with AppImage and Deb targets. Auto-publish is also disabled for local Windows and Linux builds to prevent unintended releases.

---
<a href="https://cursor.com/background-agent?bcId=bc-9741d139-09a1-4d80-879b-4761d1cf8f8c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9741d139-09a1-4d80-879b-4761d1cf8f8c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

